### PR TITLE
fix the typo on deleting pid_file

### DIFF
--- a/bin/runnel
+++ b/bin/runnel
@@ -101,7 +101,7 @@ class Runnel
   def running?
     if File.exists?(pid_file)
       if `ps #{pid} | grep autossh`.length == 0
-        File.delete(file)
+        File.delete(pid_file)
         false
       else
         true


### PR DESCRIPTION
Just a simple typo fix. Would be great if it can be merged & gem version bumped :)

Thanks!
