### PR TITLE
Don't start again if running

### DIFF
--- a/bin/runnel
+++ b/bin/runnel
@@ -110,10 +110,15 @@ class Runnel
   end
 
   def start
-    puts "Starting #{conf[:name]}"
-    puts "AUTOSSH_PIDFILE=#{pid_file} autossh -M #{conf[:mport]} #{conf[:command]}"
-    ENV['AUTOSSH_PIDFILE'] = pid_file
-    `autossh -M #{conf[:mport]} #{conf[:command]}`
+    if running?
+      puts "It seems like #{conf[:name]} is already running:"
+      puts pp_description
+    else
+      puts "Starting #{conf[:name]}"
+      puts "AUTOSSH_PIDFILE=#{pid_file} autossh -M #{conf[:mport]} #{conf[:command]}"
+      ENV['AUTOSSH_PIDFILE'] = pid_file
+      `autossh -M #{conf[:mport]} #{conf[:command]}`
+    end
   end
 
   def kill

--- a/bin/runnel
+++ b/bin/runnel
@@ -111,8 +111,8 @@ class Runnel
 
   def start
     if running?
-      puts "It seems like #{conf[:name]} is already running:"
-      puts pp_description
+      warn "It seems like #{conf[:name]} is already running:"
+      warn pp_description
     else
       puts "Starting #{conf[:name]}"
       puts "AUTOSSH_PIDFILE=#{pid_file} autossh -M #{conf[:mport]} #{conf[:command]}"
@@ -125,7 +125,7 @@ class Runnel
     if running?
       `kill #{pid}`
     else
-      puts "Unable to find a running #{conf[:name]}"
+      warn "Unable to find a running #{conf[:name]}"
     end
   end
 

--- a/bin/runnel
+++ b/bin/runnel
@@ -174,6 +174,14 @@ else
     else
       Runnel.start_all
     end
+  when "restart"
+    if ARGV[1]
+      Runnel.kill(ARGV[1])
+      Runnel.start(ARGV[1])
+    else
+      Runnel.kill_all
+      Runnel.start_all
+    end
   when "help"
     puts HELP
   else


### PR DESCRIPTION
Not sure if it's a problem for anyone else, but I often find myself with multiple processes running for the same tunnel, where runnel has been invoked multiple times with the same tunnel id and lost track of the older pids.

(Thanks for a neat tool. I used a GUI-based tunnel manager before, but it's great to be able to start and stop the tunnels from scripts as well.)
